### PR TITLE
fix: comm status ready

### DIFF
--- a/diplomacy/engine/game.py
+++ b/diplomacy/engine/game.py
@@ -1976,7 +1976,7 @@ class Game(Jsonable):
 
         LOGGER.info(power_name + "\t" + "comm_status: " + comm_status)
         power = self.get_power(power_name.upper())
-        power.comm_status = comm_status
+        power.comm_status = strings.READY
 
     def set_wait(self, power_name, wait):
         """Set wait flag for a power.

--- a/diplomacy/engine/power.py
+++ b/diplomacy/engine/power.py
@@ -80,7 +80,7 @@ class Power(Jsonable):
         strings.UNITS: parsing.DefaultValueType(parsing.SequenceType(str), []),
         strings.VOTE: parsing.DefaultValueType(parsing.EnumerationType(strings.ALL_VOTE_DECISIONS), strings.NEUTRAL),
         strings.WAIT: parsing.DefaultValueType(bool, True),
-        strings.COMM_STATUS: parsing.DefaultValueType(str, strings.BUSY),
+        strings.COMM_STATUS: parsing.DefaultValueType(str, strings.READY),
         strings.PLAYER_TYPE: parsing.DefaultValueType(parsing.EnumerationType(strings.ALL_PLAYER_TYPES), strings.NONE)
     }
 
@@ -100,7 +100,7 @@ class Power(Jsonable):
         self.vote = ''
         self.order_is_set = 0
         self.wait = False
-        self.comm_status = strings.BUSY
+        self.comm_status = strings.READY
         self.player_type = strings.NONE
         self.tokens = set()
         super(Power, self).__init__(name=name, **kwargs)
@@ -186,11 +186,11 @@ class Power(Jsonable):
             if self.is_eliminated():
                 self.order_is_set = OrderSettings.ORDER_SET_EMPTY
                 self.wait = False
-                self.comm_status = strings.BUSY
+                self.comm_status = strings.READY
             else:
                 self.order_is_set = OrderSettings.ORDER_NOT_SET
                 self.wait = True if self.is_dummy() else (not self.game.real_time)
-                self.comm_status = strings.BUSY
+                self.comm_status = strings.READY
         self.goner = 0
 
     @staticmethod
@@ -220,7 +220,7 @@ class Power(Jsonable):
         self.game = game
         self.order_is_set = OrderSettings.ORDER_NOT_SET
         self.wait = True if self.is_dummy() else (not self.game.real_time)
-        self.comm_status = strings.BUSY
+        self.comm_status = strings.READY
 
         # Get power abbreviation.
         self.abbrev = self.game.map.abbrev.get(self.name, self.name[0])
@@ -373,7 +373,7 @@ class Power(Jsonable):
                 self.controller.put(common.timestamp_microseconds(), strings.DUMMY)
                 self.tokens.clear()
                 self.wait = True
-                self.comm_status = strings.BUSY
+                self.comm_status = strings.READY
                 self.vote = strings.NEUTRAL
         elif self.controller.last_value() == strings.DUMMY:
             self.controller.put(common.timestamp_microseconds(), username)

--- a/diplomacy/web/src/diplomacy/engine/power.js
+++ b/diplomacy/web/src/diplomacy/engine/power.js
@@ -47,7 +47,7 @@ export class Power {
             RUSSIA: false,
             TURKEY: false
         };
-        this.comm_status = STRINGS.BUSY;
+        this.comm_status = STRINGS.READY;
         this.player_type = null;
     }
 
@@ -168,7 +168,7 @@ export class Power {
         this.orders = [];
         this.order_is_set = 0;
         this.wait = !this.game.isRealTime();
-        this.comm_status = STRINGS.BUSY;
+        this.comm_status = STRINGS.READY;
     }
 
     clearUnits() {

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -1196,7 +1196,7 @@ export class ContentGame extends React.Component {
 
     setCommStatus(commStatus) {
         let newCommStatus =
-            commStatus === STRINGS.BUSY ? STRINGS.READY : STRINGS.BUSY;
+            commStatus === STRINGS.READY ? STRINGS.READY : STRINGS.READY;
         const engine = this.props.data;
         const networkGame = engine.client;
         const controllablePowers = engine.getControllablePowers();

--- a/diplomacy/web/src/gui/utils/power_view.jsx
+++ b/diplomacy/web/src/gui/utils/power_view.jsx
@@ -82,7 +82,7 @@ function getWaitFlag(power) {
 function getCommStatusFlag(power) {
     if (power.isEliminated())
         return <span className="dummy"><em>N/A</em></span>;
-    return <span className={power.comm_status === STRINGS.BUSY ? 'busy' : 'ready'}>{power.comm_status === STRINGS.BUSY ? 'busy' : 'ready'}</span>;
+    return <span className={power.comm_status === 'ready'}>{power.comm_status === 'ready'}</span>;
 
 }
 


### PR DESCRIPTION
Fix for comm status. Now all comm status should be ready. Since I don't see a use for comm status for human games, I replaced all `BUSY` with `READY`.