### PR TITLE
reset arrows of hovering on order advice on game process

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -530,6 +530,7 @@ export class ContentGame extends React.Component {
                         messageHighlights: {},
                         orderBuildingPath: [],
                         hasInitialOrders: false,
+                        hoverOrders: [],
                         stances: {},
                     }).then(() =>
                         this.getPage().info(
@@ -892,7 +893,7 @@ export class ContentGame extends React.Component {
             .then(() => {
                 page.success("Game processed.");
                 this.props.data.clearInitialOrders();
-                return this.setState({ hasInitialOrders: false });
+                return this.setState({ hasInitialOrders: false, hoverOrders: [] });
             })
             .catch((err) => {
                 page.error(err.toString());


### PR DESCRIPTION
Previously, move advice will show up on the map when player hover cursor on it. When game processes, the arrows remains. This PR fixes this problem.