### PR TITLE
Improve game pause logic

### DIFF
--- a/diplomacy/server/server.py
+++ b/diplomacy/server/server.py
@@ -784,9 +784,17 @@ class Server:
         """
         if server_game.is_game_active and (
                 server_game.count_controlled_powers() < server_game.get_expected_controls_count()):
-            server_game.set_status(strings.FORMING)
-            self.unschedule_game(server_game)
-            Notifier(self).notify_game_status(server_game)
+
+            stop_game = False
+
+            for power in server_game.powers.values():
+                if not power.is_eliminated() and not power.is_controlled():
+                    stop_game = True
+                    break
+            if stop_game:
+                server_game.set_status(strings.FORMING)
+                self.unschedule_game(server_game)
+                Notifier(self).notify_game_status(server_game)
 
     def user_is_master(self, username, server_game):
         """ Return True if given username is a game master for given game data.

--- a/diplomacy/server/server_game.py
+++ b/diplomacy/server/server_game.py
@@ -511,8 +511,14 @@ class ServerGame(Game):
         # Process game and retrieve previous state.
         previous_phase_data = super(ServerGame, self).process()
         if self.count_controlled_powers() < self.get_expected_controls_count():
-            # There is no more enough controlled powers, we should stop game.
-            self.set_status(strings.FORMING)
+            pause = False
+            for power in self.powers.values():
+                if not power.is_eliminated() and not power.is_controlled():
+                    pause = True
+                    break
+            # Only stop the game when there is at least one non-eliminated power controlled by a user.
+            if pause:
+                self.set_status(strings.FORMING)
 
         # Return process results: previous phase data, current phase data, and None for no kicked powers.
         return previous_phase_data, self.get_phase_data(), None


### PR DESCRIPTION
Previously, game will be paused when **num_players** < **n_control**, even when they are eliminated. This PR contains a fix so that game won't automatically pause under that condition.