### PR TITLE
Hide comm status bubble for non-admins

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -1903,7 +1903,7 @@ export class ContentGame extends React.Component {
                               STRINGS.READY
                                 ? "available"
                                 : "dnd"
-                            : "invisible"
+                            : null
                     }
                 />
             </Conversation>


### PR DESCRIPTION
QoL update: remove comm status bubbles from power icons