### PR TITLE
Use `SuggestionType` everywhere

### DIFF
--- a/diplomacy/utils/constants.py
+++ b/diplomacy/utils/constants.py
@@ -69,8 +69,3 @@ class SuggestionType(IntFlag):
     MOVE = 2
     COMMENTARY = 4
     OPPONENT_MOVE = 8
-
-    # Old aliases for backwards compatibility
-    MESSAGE_ONLY = MESSAGE
-    MOVE_ONLY = MOVE
-    MESSAGE_AND_MOVE = MESSAGE | MOVE

--- a/diplomacy/utils/constants.py
+++ b/diplomacy/utils/constants.py
@@ -70,3 +70,26 @@ class SuggestionType(IntFlag):
     MOVE = 2
     COMMENTARY = 4
     OPPONENT_MOVE = 8
+
+    @classmethod
+    def parse(cls, string: str) -> "SuggestionType":
+        """Parse string representation of flags into an enum.
+
+        For example:
+        >>> SuggestionType.parse("MOVE|MESSAGE")
+        <SuggestionType.MOVE|MESSAGE: 3>
+        """
+        names = string.split("|")
+        value = SuggestionType.NONE
+        for name in names:
+            value |= SuggestionType[name]
+        return value
+
+    def to_parsable(self) -> str:
+        """Convert enum to a parseable string representation.
+
+        For example:
+        >>> (SuggestionType.MOVE | SuggestionType.MESSAGE).to_parsable()
+        'MOVE|MESSAGE'
+        """
+        return str(self)[len(self.__class__.__name__)+1:]

--- a/diplomacy/utils/constants.py
+++ b/diplomacy/utils/constants.py
@@ -15,7 +15,7 @@
 #  with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ==============================================================================
 """ Some constant / config values used in Diplomacy package. """
-from enum import IntFlag
+from enum import IntFlag, unique
 
 # Number of times to try to connect before throwing an exception.
 NB_CONNECTION_ATTEMPTS = 12
@@ -61,6 +61,7 @@ class OrderSettings:
     ALL_SETTINGS = {ORDER_NOT_SET, ORDER_SET_EMPTY, ORDER_SET}
 
 
+@unique
 class SuggestionType(IntFlag):
     """Type of suggestions an advisor provides."""
 

--- a/diplomacy/web/src/diplomacy/utils/utils.js
+++ b/diplomacy/web/src/diplomacy/utils/utils.js
@@ -187,6 +187,14 @@ export const UTILS = {
             return UTILS.html.isInput(element) && element.type === 'password';
         }
 
-    }
+    },
+
+    SuggestionType: {
+        NONE: 0,
+        MESSAGE: 1,
+        MOVE: 2,
+        COMMENTARY: 4,
+        OPPONENT_MOVE: 8,
+    },
 
 };

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -1715,13 +1715,7 @@ export class ContentGame extends React.Component {
     }
 
     getSuggestionType(currentPowerName, engine, globalMessages) {
-        /*
-         0: NONE
-         1: MESSAGE
-         2: MOVE
-         4: COMMENTARY
-        */
-        let suggestionType = 0;
+        let suggestionType = UTILS.SuggestionType.NONE;
 
         const powerSuggestions = globalMessages.filter(
             (msg) => msg.type === STRINGS.HAS_SUGGESTIONS
@@ -2536,7 +2530,7 @@ export class ContentGame extends React.Component {
                                         value="messages"
                                     />
                                     {suggestionType !== null &&
-                                        (suggestionType & 4) === 4 && (
+                                        (suggestionType & UTILS.SuggestionType.COMMENTARY) === UTILS.SuggestionType.COMMENTARY && (
                                             <Tab2
                                                 label={
                                                     this.state.showBadge ? (
@@ -3150,10 +3144,10 @@ export class ContentGame extends React.Component {
 
         const suggestionTypeDisplay = [];
         if (suggestionType !== null) {
-            if ((suggestionType & 1) === 1)
+            if ((suggestionType & UTILS.SuggestionType.MESSAGE) === UTILS.SuggestionType.MESSAGE)
                 suggestionTypeDisplay.push("message");
-            if ((suggestionType & 2) === 2) suggestionTypeDisplay.push("move");
-            if ((suggestionType & 4) === 4)
+            if ((suggestionType & UTILS.SuggestionType.MOVE) === UTILS.SuggestionType.MOVE) suggestionTypeDisplay.push("move");
+            if ((suggestionType & UTILS.SuggestionType.COMMENTARY) === UTILS.SuggestionType.COMMENTARY)
                 suggestionTypeDisplay.push("commentary");
         }
 
@@ -3165,16 +3159,16 @@ export class ContentGame extends React.Component {
                         year
                     </div>
                 )}
-                {suggestionType !== null && suggestionType === 0 && (
+                {suggestionType !== null && suggestionType === UTILS.SuggestionType.NONE && (
                     <div>You are on your own this turn.</div>
                 )}
-                {suggestionType !== null && suggestionType >= 1 && (
+                {suggestionType !== null && suggestionType !== UTILS.SuggestionType.NONE && (
                     <div>
                         You are getting advice this turn:{" "}
                         {suggestionTypeDisplay.join(", ")}.
                     </div>
                 )}
-                {suggestionType !== null && (suggestionType & 2) === 2 && (
+                {suggestionType !== null && (suggestionType & UTILS.SuggestionType.MOVE) === UTILS.SuggestionType.MOVE && (
                     <ChatContainer
                         style={{
                             display: "flex",
@@ -3644,7 +3638,7 @@ export class ContentGame extends React.Component {
         );
 
         const hasMoveSuggestion =
-            suggestionType !== null && (suggestionType & 2) === 2;
+            suggestionType !== null && (suggestionType & UTILS.SuggestionType.MOVE) === UTILS.SuggestionType.MOVE;
 
         let gameContent;
 


### PR DESCRIPTION
This PR contains multiple changes related to `SuggestionType`. The two main ones are:

- Adding serialization and deserialization of the enum to/from a string format for easier argument passing. I've tested it out with Cicero, and I'll make a PR in that repository after this PR is merged.
- Replacing all magic numbers for suggestion type in the front end