### PR TITLE
fix: default player status to wait

### DIFF
--- a/diplomacy/engine/power.py
+++ b/diplomacy/engine/power.py
@@ -99,7 +99,7 @@ class Power(Jsonable):
         self.controller = SortedDict(int, str)
         self.vote = ''
         self.order_is_set = 0
-        self.wait = False
+        self.wait = True
         self.comm_status = strings.READY
         self.player_type = strings.NONE
         self.tokens = set()

--- a/diplomacy/engine/power.py
+++ b/diplomacy/engine/power.py
@@ -189,7 +189,7 @@ class Power(Jsonable):
                 self.comm_status = strings.READY
             else:
                 self.order_is_set = OrderSettings.ORDER_NOT_SET
-                self.wait = True if self.is_dummy() else (not self.game.real_time)
+                self.wait = True
                 self.comm_status = strings.READY
         self.goner = 0
 
@@ -219,7 +219,7 @@ class Power(Jsonable):
 
         self.game = game
         self.order_is_set = OrderSettings.ORDER_NOT_SET
-        self.wait = True if self.is_dummy() else (not self.game.real_time)
+        self.wait = True
         self.comm_status = strings.READY
 
         # Get power abbreviation.
@@ -377,7 +377,6 @@ class Power(Jsonable):
                 self.vote = strings.NEUTRAL
         elif self.controller.last_value() == strings.DUMMY:
             self.controller.put(common.timestamp_microseconds(), username)
-            self.wait = not self.game.real_time
             if player_type is not None:
                 self.player_type = player_type
         elif self.controller.last_value() != username:

--- a/diplomacy/web/src/diplomacy/engine/power.js
+++ b/diplomacy/web/src/diplomacy/engine/power.js
@@ -29,7 +29,7 @@ export class Power {
         this.controller = new SortedDict();
         this.vote = null;
         this.order_is_set = 0;
-        this.wait = !this.game.isRealTime();
+        this.wait = true;
         this.centers = [];
         this.homes = [];
         this.units = [];
@@ -167,7 +167,7 @@ export class Power {
     clearOrders() {
         this.orders = [];
         this.order_is_set = 0;
-        this.wait = !this.game.isRealTime();
+        this.wait = true;
         this.comm_status = STRINGS.READY;
     }
 


### PR DESCRIPTION
- players can be late in human games, setting one move when others are ready will process the game. This fix prevents auto-processing.