### PR TITLE
remove neutral msg btn

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2124,21 +2124,6 @@ export class ContentGame extends React.Component {
                                             this.setMessageInputValue("");
                                         }}
                                     ></Button>
-                                    <Button
-                                        key={"n"}
-                                        pickEvent={true}
-                                        title={"Neutral"}
-                                        color={"primary"}
-                                        onClick={() => {
-                                            this.sendMessage(
-                                                engine.client,
-                                                currentTabId,
-                                                this.state.message,
-                                                "Neutral"
-                                            );
-                                            this.setMessageInputValue("");
-                                        }}
-                                    ></Button>
                                 </>
                             )}
                         </Box>


### PR DESCRIPTION
This PR remove the send `neutral` message button so that there is only `lie` and `truth`. This is for CTRL-D discussed in the meeting as it cannot process neutral statements.