### PR TITLE
Fix failing `trailing-whitespace` check

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -3509,7 +3509,7 @@ export class ContentGame extends React.Component {
                         ))}
                     </select>
                 </div>
-                    
+
                 {(controllablePowers.length === 1 && (
                     <span className="power-name">{controllablePowers[0]}</span>
                 )) || (


### PR DESCRIPTION
This check failure wasn't caught before merging to `main`.