### PR TITLE
Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,95 @@
+name: Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - test-ci**
+  workflow_dispatch: # Enable workflow to be run manually
+
+# Disable all access to the GitHub API by default
+# This default can be overridden for individual workflows and jobs
+# Documentation: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
+permissions: {}
+
+# Cancel the currently running CI job if you push a change while CI is running
+# Documentation: https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODEJS_VERSION: 22.14.0
+
+jobs:
+  checks:
+    runs-on: ubuntu-22.04 # Pinned version of `ubuntu-latest`
+    name: Run checks
+    env:
+      PYTHON_VERSION: 3.11.11
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize NodeJS environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+          cache: npm
+          cache-dependency-path: diplomacy/web/package-lock.json
+      - name: Install dependencies into NodeJS environment
+        run: |
+          make update-npm
+
+      - name: Initialize Python environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install dependencies into Python environment
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade -e .[dev]
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: precommit--${{ runner.os }}--${{ runner.arch }}--${{ env.PYTHON_VERSION }}--${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run all checks
+        run: |
+          SKIP=no-commit-to-branch make check
+
+  # Run tests for Python 3.7 to limit any version-related breakages in Cicero
+  checks-py37:
+    runs-on: ubuntu-22.04 # Pinned version of `ubuntu-latest`
+    name: Run Python 3.7 checks
+    env:
+      PYTHON_VERSION: 3.7.17
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize Python environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: requirements-lock.txt
+      - name: Install dependencies into Python environment
+        run: |
+          make update-pip
+
+      - name: Run tests
+        run: |
+          make pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ RUN npm install --force
 COPY diplomacy/web/ /app
 COPY diplomacy/maps/ /maps
 
-# Needed to work around changes in OpenSSL 3.0
-ENV NODE_OPTIONS=--openssl-legacy-provider
-
 RUN npm run build
 
 FROM python:3.7.17-alpine3.18 AS server

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 .PHONY: check-npm-build
 check-npm-build:
 	cd diplomacy/web/ && \
-	NODE_OPTIONS=--openssl-legacy-provider npm run build
+	npm run build
 
 .PHONY: eslint
 eslint:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ eslint:
 	cd diplomacy/web/ && \
 	npx eslint --ext js,jsx .
 
+.PHONY: npm-test
+npm-test:
+	cd diplomacy/web/ && \
+	npm run test
+
 .PHONY: precommit
 precommit:
 	pre-commit run --all-files
@@ -58,6 +63,7 @@ check:
 	$(MAKE) sphinx
 	# $(MAKE) eslint
 	$(MAKE) check-npm-build
+	$(MAKE) npm-test
 
 .PHONY: update-npm
 update-npm:

--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,12 @@ sphinx:
 .PHONY: check
 check:
 	$(MAKE) precommit
-	$(MAKE) pytest
-	# $(MAKE) pylint
-	$(MAKE) sphinx
-	# $(MAKE) eslint
 	$(MAKE) check-npm-build
+	# $(MAKE) pylint
+	# $(MAKE) eslint
+	$(MAKE) sphinx
 	$(MAKE) npm-test
+	$(MAKE) pytest
 
 .PHONY: update-npm
 update-npm:

--- a/diplomacy/web/package.json
+++ b/diplomacy/web/package.json
@@ -26,9 +26,9 @@
   },
   "scripts": {
     "start": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
+    "test": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts test --env=jsdom",
+    "eject": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts eject"
   },
   "devDependencies": {
     "eslint-plugin-react": "^7.14.2"

--- a/diplomacy/web/package.json
+++ b/diplomacy/web/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "start": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
     "build": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
-    "test": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts test --env=jsdom",
+    "test": "export CI=true NODE_OPTIONS=--openssl-legacy-provider && react-scripts test --env=jsdom --passWithNoTests",
     "eject": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts eject"
   },
   "devDependencies": {

--- a/diplomacy/web/package.json
+++ b/diplomacy/web/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "start": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
-    "build": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
+    "build": "export CI=false NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
     "test": "export CI=true NODE_OPTIONS=--openssl-legacy-provider && react-scripts test --env=jsdom --passWithNoTests",
     "eject": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts eject"
   },


### PR DESCRIPTION
This PR adds CI to ensure we don't accidentally merge PRs that are failing checks into `main`.

Running GitHub Actions is _much_ slower than running locally (at least on my laptop), so I highly recommend running `make check` locally before pushing to resolve problems more quickly.