### PR TITLE
fix tap influence bug

### DIFF
--- a/diplomacy/engine/game.py
+++ b/diplomacy/engine/game.py
@@ -5511,6 +5511,13 @@ class Game(Jsonable):
                         power.units += [" ".join(word[:2])]
                         diff += 1
                         self.result[unit] += [OK]
+
+                        loc = word[1] if len(word[1]) == 3 else word[1][:3]
+                        # Setting influence
+                        for influence_power in self.powers.values():
+                            if loc in influence_power.influence:
+                                influence_power.influence.remove(loc)
+                        power.influence.append(loc)
                     else:
                         self.result[unit] += [VOID]
                     if unit not in self.ordered_units[power.name]:


### PR DESCRIPTION
Fixed a bug that prevents power moving units.
Steps to reproduce:
- in a spring movement, an adversary moves into an unoccupied home supply center
- in the subsequent fall movement, the power owning the home SC moves out
- the power owning the home SC moves builds a unit in that particular SC
- in the next turn, the power cannot use the interface to issue orders for the newly-build unit

An example can be found in game `admin_1743974688140` on diplomacy.alexhedges.dev where Russia is unable to issue orders for fleet in STP