### PR TITLE
Readd "advice" to advice type message

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -3661,7 +3661,7 @@ export class ContentGame extends React.Component {
                 )}
                 {suggestionType !== null && suggestionType !== UTILS.SuggestionType.NONE && (
                     <div>
-                        You are getting:{" "}
+                        You are getting advice:{" "}
                         {/* `reduce()` call used to "`join()`" React elements
                         (from https://stackoverflow.com/questions/34034038/how-to-render-react-components-by-using-map-and-join/35840806#35840806)
                         */}


### PR DESCRIPTION
This message originally said "You are getting advice this turn", but Feng shortened it to "You are getting" in 6a1ef12[^1] to make the UI more compact. However, Jono pointed out today that it's not clear that the message is about advice, so I am changing it to "You are getting advice", which is longer than it was before but still two words shorter than the original wording.

[^1]: https://github.com/ALLAN-DIP/diplomacy/commit/6a1ef121506a864c8fe2646de83ea9e96e13dd71