### PR TITLE
merge commentary together

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -1859,7 +1859,6 @@ export class ContentGame extends React.Component {
         const receivedSuggestions = globalMessages.filter(
             (msg) =>
                 msg.type === STRINGS.SUGGESTED_COMMENTARY &&
-                msg.parsed.payload.recipient === protagonist &&
                 (isAdmin ||
                     !this.state.annotatedMessages.hasOwnProperty(msg.time_sent))
         );
@@ -1878,7 +1877,6 @@ export class ContentGame extends React.Component {
             this.setState({
                 numAllCommentary: numCommentary,
                 showBadge: true,
-                commentaryProtagonist: protagonist,
             });
         } // update numAllCommentary and show badge if new commentary is received
 
@@ -2703,8 +2701,7 @@ export class ContentGame extends React.Component {
                                         <ConversationHeader>
                                             <ConversationHeader.Content
                                                 userName={
-                                                    "Commentary about " +
-                                                    protagonist
+                                                    "Commentary"
                                                 }
                                             />
                                         </ConversationHeader>


### PR DESCRIPTION
Per @YanzeJeremy 's request, this PR merges the commentary together, specifically:
- there is no interface change except for removing "commentary about {power}" in the header
- removed filtering commentary by power accordingly