### PR TITLE
Fix order probability advice not displaying on Windows

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -3838,7 +3838,7 @@ export class ContentGame extends React.Component {
         this.props.data.displayed = true;
 
         document.onkeydown = (event) => {
-            if (event.key === "Shift"){
+            if (event.key === "Shift" && !event.repeat){
                 this.setState({
                     shiftKeyPressed: true,
                     orderDistribution: [],


### PR DESCRIPTION
Closes #89.

During games, some participants encountered a problem where the order probability advice feature would not work on Windows: the probabilities would display briefly before disappearing. We didn't notice this feature during the months of development because we were only testing on macOS. However, almost all study participants are using Windows, so solving this problem was a high priority!

After the various trials and tribulations involved in getting a Windows machine and reproducing the bug, I used Javascript Key Event Tester[^1] to discover the problem. It turns out that when you hold a key on Mac (as we do here with `Shift`), only a single `keydown` event is triggered. However, on Windows, holding a key will trigger tens of `keydown` events per second. This behavior isn't documented in the "Auto-repeat handling" section of the MDN page for `KeyboardEvent`,[^2] but it makes sense because holding a key on Mac in any application does not repeatedly enter the held character. The behavior is a specific problem in our case because every `keydown` event clears the display state of probabilities, and the rapid events are causing this state to be repeatedly recalculated and cleared.

Fortunately, I was able to find a solution! According to the MDN page for `KeyboardEvent.repeat`:[^3]

> The `repeat` read-only property of the `KeyboardEvent` interface
> returns a boolean value that is `true` if the given key is being held
> down such that it is automatically repeating.

I installed a test event listener by entering the following line in browser development consoles:

```js
document.onkeydown = (event) => console.log(event.key, event.repeat);
```

I was able to confirm that the repetition was being correctly detected on Windows! Therefore, the solution is an extremely simple change to only make changes when the event is non-repeated.

According to the MDN page, there is a problem in Chrome's implementation that could hypothetically cause a bug, but Joy's testing didn't encounter it. Even if it _did_ happen, telling someone to use Edge or Firefox instead is at least better than before!

As a side note, according to "How to Enable Key Repeating in macOS",[^4] the Windows behavior _can_ theoretically be enabled on macOS. This might be useful if we encounter a problem like this again.

[^1]: https://unixpapa.com/js/testkey.html
[^2]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#auto-repeat_handling
[^3]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat
[^4]: https://www.howtogeek.com/267463/how-to-enable-key-repeating-in-macos/