### PR TITLE
Make `Game.get_all_possible_orders()` output deterministic

### DIFF
--- a/diplomacy/engine/game.py
+++ b/diplomacy/engine/game.py
@@ -2612,7 +2612,7 @@ class Game(Jsonable):
                             possible_orders[loc].add("WAIVE")
 
         # Returning
-        return {loc: list(possible_orders[loc]) for loc in possible_orders}
+        return {loc: sorted(possible_orders[loc]) for loc in possible_orders}
 
     # ====================================================================
     #   Private Interface - CONVOYS Methods


### PR DESCRIPTION
The output includes a `list` created from a `set`, so the order can differ across runs. The `list` should be sorted for consistency.

I fixed this back when I was working on <https://github.com/ALLAN-DIP/chiron-utils/pull/42>, but I never made a PR because it wasn't required to solve the immediate problem.