### PR TITLE
Fix centaur tab display

### DIFF
--- a/diplomacy/web/src/diplomacy/utils/strings.js
+++ b/diplomacy/web/src/diplomacy/utils/strings.js
@@ -49,6 +49,11 @@ export const STRINGS = {
     SUGGESTED_MOVE_OPPONENTS: "suggested_move_opponents",
     SUGGESTED_MOVE_PARTIAL: "suggested_move_partial",
     // Suggestion message types (end)
+    // Centaur tab values (start)
+    MESSAGES: "messages",
+    COMMENTARY: "commentary",
+    INTENT_LOG: "intent-log",
+    // Centaur tab values (end)
     ALL_GAME_STATUSES: ["forming", "active", "paused", "completed", "canceled"],
     ALL_POWER_NAMES: ["AUSTRIA", "ENGLAND", "FRANCE", "GERMANY", "ITALY", "RUSSIA", "TURKEY"],
     RULES: [

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2159,6 +2159,16 @@ export class ContentGame extends React.Component {
             [STRINGS.INTENT_LOG]: isAdmin,
         };
 
+        // If tab is disabled, choose the first displayed tab
+        if (displayTab[this.state.tabVal] === false) {
+            for (const [key, value] of Object.entries(displayTab)) {
+                if (value === true) {
+                    this.setState({ tabVal: key });
+                    break;
+                }
+            }
+        }
+
         return (
             <Box className={"col-6 mb-4"}>
                 <Grid container spacing={2}>

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2168,17 +2168,19 @@ export class ContentGame extends React.Component {
                                     {this.hasSuggestionType(suggestionType, UTILS.SuggestionType.COMMENTARY) && (
                                         <Tab2
                                             label={
-                                                this.state.showBadge ? (
-                                                    <Badge variant="dot" color="warning"></Badge>
-                                                ) : (
-                                                    <span
-                                                        sx={{
-                                                            marginRight: "8px",
-                                                        }}
-                                                    >
-                                                        Commentary
-                                                    </span>
-                                                )
+                                                <span
+                                                    sx={{
+                                                        marginRight: "8px",
+                                                    }}
+                                                >
+                                                    Commentary
+                                                    {this.state.showBadge && (
+                                                        <>
+                                                            {" "}
+                                                            <Badge variant="dot" color="warning"></Badge>
+                                                        </>
+                                                    )}
+                                                </span>
                                             }
                                             value="commentary"
                                             onClick={() => {

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2151,6 +2151,14 @@ export class ContentGame extends React.Component {
         );
         const curController = engine.powers[role].getController();
 
+        // Use computed property names because there is no other way to use constants as object literal keys
+        // Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names
+        const displayTab = {
+            [STRINGS.MESSAGES]: this.hasSuggestionType(suggestionType, UTILS.SuggestionType.MESSAGE),
+            [STRINGS.COMMENTARY]: this.hasSuggestionType(suggestionType, UTILS.SuggestionType.COMMENTARY),
+            [STRINGS.INTENT_LOG]: isAdmin,
+        };
+
         return (
             <Box className={"col-6 mb-4"}>
                 <Grid container spacing={2}>
@@ -2162,10 +2170,10 @@ export class ContentGame extends React.Component {
                                     onChange={this.updateTabVal}
                                     aria-label="basic tabs example"
                                 >
-                                    {this.hasSuggestionType(suggestionType, UTILS.SuggestionType.MESSAGE) && (
+                                    {displayTab[STRINGS.MESSAGES] && (
                                         <Tab2 label="Message Advice" value={STRINGS.MESSAGES} />
                                     )}
-                                    {this.hasSuggestionType(suggestionType, UTILS.SuggestionType.COMMENTARY) && (
+                                    {displayTab[STRINGS.COMMENTARY] && (
                                         <Tab2
                                             label={
                                                 <span
@@ -2194,7 +2202,9 @@ export class ContentGame extends React.Component {
                                             }}
                                         />
                                     )}
-                                    {isAdmin && <Tab2 label="Captain's Log" value={STRINGS.INTENT_LOG} />}
+                                    {displayTab[STRINGS.INTENT_LOG] && (
+                                        <Tab2 label="Captain's Log" value={STRINGS.INTENT_LOG} />
+                                    )}
                                 </Tabs2>
                             </Box>
                             {this.state.tabVal === STRINGS.MESSAGES && (

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2162,7 +2162,9 @@ export class ContentGame extends React.Component {
                                     onChange={this.updateTabVal}
                                     aria-label="basic tabs example"
                                 >
-                                    <Tab2 label="Message Advice" value="messages" />
+                                    {this.hasSuggestionType(suggestionType, UTILS.SuggestionType.MESSAGE) && (
+                                        <Tab2 label="Message Advice" value="messages" />
+                                    )}
                                     {this.hasSuggestionType(suggestionType, UTILS.SuggestionType.COMMENTARY) && (
                                         <Tab2
                                             label={

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -202,7 +202,7 @@ export class ContentGame extends React.Component {
                 TURKEY: false,
             },
             hoverOrders: [],
-            tabVal: "messages",
+            tabVal: STRINGS.MESSAGES,
             numAllCommentary: 0,
             numReadCommentary: 0,
             showBadge: false,
@@ -749,7 +749,7 @@ export class ContentGame extends React.Component {
     updateTabVal(event, value) {
         const now = Date.now();
 
-        if (value === "messages") {
+        if (value === STRINGS.MESSAGES) {
             // track time spent on commentary
             const timeDiff = now - this.state.lastSwitchPanelTime;
 
@@ -884,7 +884,7 @@ export class ContentGame extends React.Component {
 
     handleExit = () => {
         // Send the commentary durations to the server on exit
-        if (this.state.tabVal === "messages") {
+        if (this.state.tabVal === STRINGS.MESSAGES) {
             return;
         }
         const now = Date.now();
@@ -2163,7 +2163,7 @@ export class ContentGame extends React.Component {
                                     aria-label="basic tabs example"
                                 >
                                     {this.hasSuggestionType(suggestionType, UTILS.SuggestionType.MESSAGE) && (
-                                        <Tab2 label="Message Advice" value="messages" />
+                                        <Tab2 label="Message Advice" value={STRINGS.MESSAGES} />
                                     )}
                                     {this.hasSuggestionType(suggestionType, UTILS.SuggestionType.COMMENTARY) && (
                                         <Tab2
@@ -2182,7 +2182,7 @@ export class ContentGame extends React.Component {
                                                     )}
                                                 </span>
                                             }
-                                            value="commentary"
+                                            value={STRINGS.COMMENTARY}
                                             onClick={() => {
                                                 if (isCurrent) {
                                                     this.setState({
@@ -2194,10 +2194,10 @@ export class ContentGame extends React.Component {
                                             }}
                                         />
                                     )}
-                                    {isAdmin && <Tab2 label="Captain's Log" value="intent-log" />}
+                                    {isAdmin && <Tab2 label="Captain's Log" value={STRINGS.INTENT_LOG} />}
                                 </Tabs2>
                             </Box>
-                            {this.state.tabVal === "messages" && (
+                            {this.state.tabVal === STRINGS.MESSAGES && (
                                 <ChatContainer
                                     style={{
                                         display: "flex",
@@ -2278,7 +2278,7 @@ export class ContentGame extends React.Component {
                                 </ChatContainer>
                             )}
 
-                            {this.state.tabVal === "commentary" && (
+                            {this.state.tabVal === STRINGS.COMMENTARY && (
                                 <MainContainer responsive>
                                     <ChatContainer>
                                         <ConversationHeader>
@@ -2319,7 +2319,7 @@ export class ContentGame extends React.Component {
                                 </MainContainer>
                             )}
 
-                            {this.state.tabVal === "intent-log" && (
+                            {this.state.tabVal === STRINGS.INTENT_LOG && (
                                 <MainContainer responsive>
                                     <ChatContainer>
                                         <ConversationHeader>


### PR DESCRIPTION
This PR fixes multiple display issues I've noticed with the centaur tabs.

Here are screenshots of the centaur tab component before and after this PR when commentary advice is available but not message advice:

- Before: ![Screenshot of UI before these changes](https://github.com/user-attachments/assets/3a023b4c-2bb3-4062-9caa-ff30ace8f543)
- After: ![Screenshot of UI after these changes](https://github.com/user-attachments/assets/1a1d288e-2ef1-4cba-add4-6fdf39f86744)