### PR TITLE
Do not read username from `localStorage`

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -3229,7 +3229,7 @@ export class ContentGame extends React.Component {
                 </Row>
                 <Row>
                     {!engine.isPlayerGame() && this.renderPowerInfo(engine)}
-                    {localStorage.getItem("username") === "admin" && this.renderLogs(engine, currentPowerName)}
+                    {page.channel.username === "admin" && this.renderLogs(engine, currentPowerName)}
                 </Row>
             </div>
         );


### PR DESCRIPTION
This was causing a log panel to be displayed for a normal player if they signed into an account named `admin` in another tab in the same browser. We already read the username from session information elsewhere on the page, so we should just read from it here as well.

Here are screenshots of the UI before and after this PR when I log into the `admin` account in another tab:

- Before:
    - `ahedges` session: ![Screenshot of UI in `ahedges` session before these changes](https://github.com/user-attachments/assets/3b7bea58-ec6c-4b13-83d0-270fa76cb5ef)
    - `admin` session: 
![Screenshot of UI in `admin` session before these changes](https://github.com/user-attachments/assets/dfbcc2ff-fd53-49cc-bc71-865c82f8477c)
- After:
    - `ahedges` session: ![Screenshot of UI in `ahedges` session after these changes](https://github.com/user-attachments/assets/60ef1b97-7cdc-452a-9491-d08c15239f8f)
    - `admin` session: ![Screenshot of UI in `admin` session after these changes](https://github.com/user-attachments/assets/3a4e4fa2-7085-459a-a776-015ec2e0427e)
