### PR TITLE
Revert "[TEST] Use branch name for VM setup files before merging"

### DIFF
--- a/vm_conf/README.md
+++ b/vm_conf/README.md
@@ -15,8 +15,8 @@ Use the following steps both for initially deploying and later redeploying the a
   ```
 - Download the latest versions of the required files with the following commands:
   ```bash
-  wget --output-document Caddyfile https://raw.githubusercontent.com/ALLAN-DIP/diplomacy/refs/heads/alex-dev/vm_conf/Caddyfile
-  wget --output-document compose.yaml https://raw.githubusercontent.com/ALLAN-DIP/diplomacy/refs/heads/alex-dev/vm_conf/compose.yaml
+  wget --output-document Caddyfile https://raw.githubusercontent.com/ALLAN-DIP/diplomacy/refs/heads/main/vm_conf/Caddyfile
+  wget --output-document compose.yaml https://raw.githubusercontent.com/ALLAN-DIP/diplomacy/refs/heads/main/vm_conf/compose.yaml
   ```
 - Start the server with the following command:
   ```bash


### PR DESCRIPTION
This reverts commit f115fd33f32f76be8833d4e68c4a18f01947bbb6.

I forgot to drop the commit before merging #101! Because this is a trivial doc change that was already reviewed, I'll just merge this once CI passes.