### PR TITLE
Move `get_messages()` from `ServerGame` to `Game`

### DIFF
--- a/diplomacy/engine/game.py
+++ b/diplomacy/engine/game.py
@@ -996,6 +996,12 @@ class Game(Jsonable):
             or message.sender in game_role
         }
 
+    def get_messages(self, game_role, timestamp_from=None, timestamp_to=None):
+        """Return a filtered dict of current messages for given output game role.
+        See method filter_messages() about parameters.
+        """
+        return self.filter_messages(self.messages, game_role, timestamp_from, timestamp_to)
+
     def get_phase_history(self, from_phase=None, to_phase=None, game_role=None):
         """Return a list of game phase data from game history between given phases (bounds included).
         Each GamePhaseData object contains game state, messages, orders and order results for a phase.

--- a/diplomacy/server/server_game.py
+++ b/diplomacy/server/server_game.py
@@ -152,12 +152,6 @@ class ServerGame(Game):
         """
         return self.is_game_forming and not self.start_master and self.has_expected_controls_count()
 
-    def get_messages(self, game_role, timestamp_from=None, timestamp_to=None):
-        """Return a filtered dict of current messages for given output game role.
-        See method filter_messages() about parameters.
-        """
-        return self.filter_messages(self.messages, game_role, timestamp_from, timestamp_to)
-
     def get_message_history(self, game_role):
         """Return a filtered dict of whole message history for given game role."""
         return {


### PR DESCRIPTION
This allows the method to be used by clients, preventing them from ever needing to interact with the unfiltered `Game.messages` field. Hopefully, this prevents any accidental message leakage.