### PR TITLE
do not display move advice unless moves are set

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -1176,7 +1176,7 @@ export class ContentGame extends React.Component {
             engine.setInitialOrders(engine.role);
             state.hasInitialOrders = true;
         }
-        
+
         this.setState(state).then(() => {
             this.__store_orders(allOrders);
             this.setOrders();

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2765,11 +2765,13 @@ export class ContentGame extends React.Component {
                         <ConversationHeader.Content userName={`Order Advice`} />
                     </ConversationHeader>
 
-                    {this.state.hasInitialOrders && (<MessageList className="move-suggestion-list">
-                        {fullSuggestionComponent}
-                        {partialSuggestionComponent}
-                        {distributionSuggestionComponent}
-                    </MessageList>)}
+                    {this.state.hasInitialOrders && (
+                        <MessageList className="move-suggestion-list">
+                            {fullSuggestionComponent}
+                            {partialSuggestionComponent}
+                            {distributionSuggestionComponent}
+                        </MessageList>
+                    )}
                 </ChatContainer>
             </div>
         );

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -1166,8 +1166,17 @@ export class ContentGame extends React.Component {
         allOrders[powerName][localOrder.loc] = localOrder;
         state.orders = allOrders;
         this.getPage().success(`Built order: ${orderString}`);
-        engine.setInitialOrders(engine.role);
-        state.hasInitialOrders = true;
+
+        const controllablePowers = engine.getControllablePowers();
+        const currentPowerName = this.state.power || (controllablePowers.length ? controllablePowers[0] : null);
+        const orderableUnits = engine.orderableLocations[currentPowerName].length;
+        const serverOrderLength = Object.keys(allOrders[powerName]).length;
+
+        if (serverOrderLength == orderableUnits) {
+            engine.setInitialOrders(engine.role);
+            state.hasInitialOrders = true;
+        }
+        
         this.setState(state).then(() => {
             this.__store_orders(allOrders);
             this.setOrders();

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2067,7 +2067,7 @@ export class ContentGame extends React.Component {
         );
     }
 
-    renderCentaurMessages(engine, role, isCurrent, isWide) {
+    renderCurrentMessageAdvice(engine, role, isCurrent, isWide) {
         const isAdmin =
             engine.role === "omniscient_type" || engine.role === "master_type" || engine.role === "observer_type";
 
@@ -2354,7 +2354,7 @@ export class ContentGame extends React.Component {
         );
     }
 
-    renderCurrentCentaur(engine, role, isCurrent) {
+    renderCurrentMoveAdvice(engine, role, isCurrent) {
         const isAdmin =
             engine.role === "omniscient_type" || engine.role === "master_type" || engine.role === "observer_type";
 
@@ -2904,16 +2904,16 @@ export class ContentGame extends React.Component {
             : this.renderPastMessages(engine, currentPowerName, isWide);
     }
 
-    renderTabCentaur(toDisplay, initialEngine, role) {
+    renderMoveAdviceTab(toDisplay, initialEngine, role) {
         const { engine, pastPhases, phaseIndex } = this.__get_engine_to_display(initialEngine);
 
-        return this.renderCurrentCentaur(engine, role, pastPhases[phaseIndex] === initialEngine.phase);
+        return this.renderCurrentMoveAdvice(engine, role, pastPhases[phaseIndex] === initialEngine.phase);
     }
 
-    renderTabCentaurMessages(toDisplay, initialEngine, role, isWide) {
+    renderMessageAdviceTab(toDisplay, initialEngine, role, isWide) {
         const { engine, pastPhases, phaseIndex } = this.__get_engine_to_display(initialEngine);
 
-        return this.renderCentaurMessages(engine, role, pastPhases[phaseIndex] === initialEngine.phase, isWide);
+        return this.renderCurrentMessageAdvice(engine, role, pastPhases[phaseIndex] === initialEngine.phase, isWide);
     }
 
     render() {
@@ -3175,7 +3175,7 @@ export class ContentGame extends React.Component {
             </div>
         );
 
-        const moveAdvicePanel = this.renderTabCentaur(true, engine, currentPowerName);
+        const moveAdvicePanel = this.renderMoveAdviceTab(true, engine, currentPowerName);
 
         const { engineCur, pastPhases, phaseIndex } = this.__get_engine_to_display(engine);
         let phasePanel;
@@ -3218,7 +3218,7 @@ export class ContentGame extends React.Component {
                 {phasePanel}
                 <Row className={"mb-4"}>
                     {this.renderTabChat(true, engine, currentPowerName, showMessageAdviceTab ? false : true)}
-                    {showMessageAdviceTab && this.renderTabCentaurMessages(true, engine, currentPowerName, false)}
+                    {showMessageAdviceTab && this.renderMessageAdviceTab(true, engine, currentPowerName, false)}
                 </Row>
                 <Row>
                     {!engine.isPlayerGame() && this.renderPowerInfo(engine)}

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2765,11 +2765,11 @@ export class ContentGame extends React.Component {
                         <ConversationHeader.Content userName={`Order Advice`} />
                     </ConversationHeader>
 
-                    <MessageList className="move-suggestion-list">
+                    {this.state.hasInitialOrders && (<MessageList className="move-suggestion-list">
                         {fullSuggestionComponent}
                         {partialSuggestionComponent}
                         {distributionSuggestionComponent}
-                    </MessageList>
+                    </MessageList>)}
                 </ChatContainer>
             </div>
         );


### PR DESCRIPTION
Per @jonmay 's request, we do not want to show move advice unless players input moves in the first place.