### PR TITLE
Fix infinite rerender loop in game UI

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2976,13 +2976,13 @@ export class ContentGame extends React.Component {
             const messageChannels = engine.getMessageChannels(currentPowerName, true);
             const suggestionMessages = this.getSuggestionMessages(currentPowerName, messageChannels, engine);
             const suggestionType = this.getSuggestionType(currentPowerName, engine, suggestionMessages);
-
-            this.setState({
-                displayVisualAdvice: this.hasSuggestionType(
-                    suggestionType,
-                    UTILS.SuggestionType.MOVE_DISTRIBUTION_VISUAL,
-                ),
-            });
+            const displayVisualAdvice = this.hasSuggestionType(
+                suggestionType,
+                UTILS.SuggestionType.MOVE_DISTRIBUTION_VISUAL,
+            );
+            if (displayVisualAdvice !== this.state.displayVisualAdvice) {
+                this.setState({ displayVisualAdvice: displayVisualAdvice });
+            }
 
             if (allowedPowerOrderTypes.length) {
                 if (this.state.orderBuildingType && allowedPowerOrderTypes.includes(this.state.orderBuildingType))


### PR DESCRIPTION
When running the application, I received the following error (linked in the console as [^1]):

> Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.

The problem is that we are calling `setState()` from within `render()` because every call retriggers `render()`. The solution here was to copy the same technique as the other two calls to `setState()` during rendering: only call the function if the value has changed. This ensures that `render()` is retriggered at most once.

Using `setState()` within `render()` is apparently discouraged in React, but properly changing that in our code would require a _huge_ refactor that we are not going to attempt.

[^1]: https://react.dev/errors/185?invariant=185