### PR TITLE
Show message/commentary panel at start of turn

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -3243,9 +3243,8 @@ export class ContentGame extends React.Component {
         );
 
         const showMessageAdviceTab =
-            (this.hasSuggestionType(suggestionType, UTILS.SuggestionType.MESSAGE) ||
-                this.hasSuggestionType(suggestionType, UTILS.SuggestionType.COMMENTARY)) &&
-            receivedSuggestions.length > 0;
+            this.hasSuggestionType(suggestionType, UTILS.SuggestionType.MESSAGE) ||
+            this.hasSuggestionType(suggestionType, UTILS.SuggestionType.COMMENTARY);
         const gameContent = (
             <div>
                 {phasePanel}


### PR DESCRIPTION
Previously, the panel would be hidden if no message or commentary advice was available. Now, the panel will be displayed from the beginning of turns where advice is given.

Here is a screenshot of the missing message/commentary panel, even though the advice types are declared:

<img width="1982" height="1226" alt="Screenshot of missing message/commentary panel" src="https://github.com/user-attachments/assets/a37863d1-4569-45fc-8b87-48eee0ab1aee" />
