### PR TITLE
Improve message blurring

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -1442,9 +1442,7 @@ export class ContentGame extends React.Component {
 
             if (role === sender) dir = "outgoing";
             if (role === rec) dir = "incoming";
-            const html = msg.hide
-                ? `<div style='color: transparent; text-shadow: 0 0 5px rgba(0, 0, 0, 0.5); user-select: none'>${msg.message}</div>`
-                : msg.message;
+            const html = msg.hide ? `<div class="blurred">${msg.message}</div>` : msg.message;
             renderedMessages.push(
                 <ChatMessage
                     model={{
@@ -1711,9 +1709,7 @@ export class ContentGame extends React.Component {
             sender = msg.sender;
             rec = msg.recipient;
             curPhase = msg.phase;
-            const html = msg.hide
-                ? `<div style='color: transparent; text-shadow: 0 0 5px rgba(0, 0, 0, 0.5); user-select: none'>${msg.message}</div>`
-                : msg.message;
+            const html = msg.hide ? `<div class="blurred">${msg.message}</div>` : msg.message;
 
             if (curPhase !== prevPhase) {
                 renderedMessages.push(<MessageSeparator key={msg.phase}>{curPhase}</MessageSeparator>);
@@ -2304,7 +2300,7 @@ export class ContentGame extends React.Component {
                                         <MessageList>
                                             {suggestedCommentaryForCurrentPower.map((com, i) => {
                                                 const html = !this.state.hasInitialOrders
-                                                    ? `<div style='color: transparent; text-shadow: 0 0 5px rgba(0, 0, 0, 0.5); user-select: none'>${com.commentary}</div>`
+                                                    ? `<div class="blurred">${com.commentary}</div>`
                                                     : com.commentary;
                                                 return (
                                                     <div

--- a/diplomacy/web/src/index.css
+++ b/diplomacy/web/src/index.css
@@ -481,3 +481,9 @@ button.collapsed .roll {
 /** Page login. **/
 /** Page games. **/
 /** Page game. **/
+
+.blurred {
+  color: transparent;
+  text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+  user-select: none;
+}

--- a/diplomacy/web/src/index.css
+++ b/diplomacy/web/src/index.css
@@ -484,6 +484,6 @@ button.collapsed .roll {
 
 .blurred {
   color: transparent;
-  text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+  text-shadow: 0 0 1em #000;
   user-select: none;
 }


### PR DESCRIPTION
I noticed that the blurred text was still somewhat readable, so I experimented with the `text-shadow` parameters. I discovered that increasing the blur radius and making the color fully opaque helps hide the text better!

Here are screenshots of the old and new blurring:

<img width="976" height="387" alt="Screenshot of old message blurring" src="https://github.com/user-attachments/assets/0f73671c-68fe-4474-8a7a-4b25f8814ba7" />
<img width="968" height="358" alt="Screenshot of new message blurring" src="https://github.com/user-attachments/assets/211ac878-ca53-4808-b0bc-74ee65ab7ccc" />
