### PR TITLE
Disable more features when orders are unset

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -1842,6 +1842,7 @@ export class ContentGame extends React.Component {
                                             );
                                             this.setMessageInputValue("");
                                         }}
+                                        disabled={!this.state.hasInitialOrders}
                                     ></Button>
                                     <Button
                                         key={"f"}
@@ -1858,6 +1859,7 @@ export class ContentGame extends React.Component {
                                             );
                                             this.setMessageInputValue("");
                                         }}
+                                        disabled={!this.state.hasInitialOrders}
                                     ></Button>
                                 </Row>
                             )}

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -3263,7 +3263,7 @@ export class ContentGame extends React.Component {
         this.props.data.displayed = true;
 
         document.onkeydown = (event) => {
-            if (event.key === "Shift" && !event.repeat) {
+            if (event.key === "Shift" && !event.repeat && this.state.hasInitialOrders) {
                 this.setState({
                     shiftKeyPressed: true,
                     orderDistribution: [],

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2267,6 +2267,7 @@ export class ContentGame extends React.Component {
                                                                         "accept",
                                                                     );
                                                                 }}
+                                                                disabled={!this.state.hasInitialOrders}
                                                                 invisible={!(isCurrent && !isAdmin)}
                                                             ></Button>
                                                             <Button
@@ -2280,6 +2281,7 @@ export class ContentGame extends React.Component {
                                                                         "reject",
                                                                     );
                                                                 }}
+                                                                disabled={!this.state.hasInitialOrders}
                                                                 invisible={!(isCurrent && !isAdmin)}
                                                             ></Button>
                                                         </div>


### PR DESCRIPTION
There were multiple features that should have been disabled until the player entered their moves, but we missed taking care of them. This PR should disable the remaining ones.