### PR TITLE
Add section header for textual order probability advice

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2755,7 +2755,20 @@ export class ContentGame extends React.Component {
                 );
             });
 
-            distributionSuggestionComponent = <div>{distributionMessages}</div>;
+            distributionSuggestionComponent = (
+                <div>
+                    <ChatMessage
+                        style={{ flexGrow: 1 }}
+                        model={{
+                            message: `Order probabilities for ${orderDistribution.province}:`,
+                            direction: "incoming",
+                            position: "single",
+                        }}
+                        avatarPosition={"tl"}
+                    ></ChatMessage>
+                    {distributionMessages}
+                </div>
+            );
         }
 
         if (


### PR DESCRIPTION
The other types of order advice have section headings, so I have added a heading to match.

Here is a screenshot showing the new heading:

![Screenshot of "Order Advice" component with the new order probability heading](https://github.com/user-attachments/assets/00bb7e0f-ba00-4c01-a8c9-8fe1cc4a9d81)