### PR TITLE
Fix order removal by human player not being sent to advisor

### DIFF
--- a/diplomacy/client/notification_managers.py
+++ b/diplomacy/client/notification_managers.py
@@ -211,6 +211,7 @@ def on_power_orders_update(game, notification):
     :type game: diplomacy.client.network_game.NetworkGame
     :type notification: diplomacy.communication.notifications.PowerOrdersUpdate
     """
+    game.get_power(notification.power_name).clear_orders()
     Game.set_orders(game, notification.power_name, notification.orders)
 
 

--- a/diplomacy/communication/notifications.py
+++ b/diplomacy/communication/notifications.py
@@ -320,7 +320,7 @@ class PowerOrdersUpdate(_GameNotification):
     }
 
     def __init__(self, **kwargs):
-        self.orders = None  # type: set
+        self.orders = None  # type: list
         super(PowerOrdersUpdate, self).__init__(**kwargs)
 
 

--- a/diplomacy/engine/game.py
+++ b/diplomacy/engine/game.py
@@ -28,6 +28,7 @@ import sys
 import time
 import random
 from copy import deepcopy
+from typing import List, Optional, Union
 
 from diplomacy import settings
 import diplomacy.utils.errors as err
@@ -1842,7 +1843,13 @@ class Game(Jsonable):
         # Clearing cache
         self.clear_cache()
 
-    def set_orders(self, power_name, orders, expand=True, replace=True):
+    def set_orders(
+        self,
+        power_name: str,
+        orders: Union[List[str], str],
+        expand: bool = True,
+        replace: bool = True,
+    ) -> None:
         """Sets the current orders for a power
 
         :param power_name: The name of the power (e.g. 'FRANCE')
@@ -1948,7 +1955,7 @@ class Game(Jsonable):
                 power.clear_centers()
         self.clear_cache()
 
-    def clear_orders(self, power_name=None):
+    def clear_orders(self, power_name: Optional[str] = None) -> None:
         """Clears the power's orders
 
         :param power_name:  Optional. The name of the power to clear (e.g. 'FRANCE') or will clear orders for
@@ -3924,7 +3931,9 @@ class Game(Jsonable):
     # ====================================================================
     #   Private Interface - ORDER Submission methods
     # ====================================================================
-    def _add_order(self, power, word, expand=True, replace=True):
+    def _add_order(
+        self, power: Optional[Power], word: List[str], expand: bool = True, replace: bool = True
+    ) -> None:
         """Adds an order for a power
         :param power: The power instance issuing the order
         :param word: The order (e.g. ['A', 'PAR', '-', 'MAR'])
@@ -3992,7 +4001,9 @@ class Game(Jsonable):
         # Returning nothing
         return None
 
-    def _update_orders(self, power, orders, expand=True, replace=True):
+    def _update_orders(
+        self, power: Optional[Power], orders: List[str], expand: bool = True, replace: bool = True
+    ) -> Union[List[str], int, None]:
         """Updates the orders of a power
 
         :param power: The power instance (or None if updating multiple instances)


### PR DESCRIPTION
This bug expressed itself by not allowing human players to receive partial order advice. The web UI does not show any advice until the player has submitted orders, so the player only saw full order advice. The only way to receive partial order advice was to clear all orders and add some again, but that is unintuitive and shouldn't be required when individual orders can be removed.

The problem was that `Game.set_orders()` takes in a list of orders and only removes an existing order if a replacement order for the same unit is provided. My initial idea was to treat the list of orders as complete instead of partial, but that breaks so much existing code that I decided to find a better solution.

`Game.set_orders()` is called in three functions relevant to order submission:

- The `on_set_orders()` request manager sets new orders on the server, calling `Power.clear_orders()` first to ensure that orders removed by the client are removed everywhere.
- The `on_set_orders()` response manager sets new orders on the client that made the request to remove orders.
- The `on_power_orders_update()` notification manager sets new orders on other clients for the same power, as well as all observing clients. The notification is triggered by the `on_set_orders()` request manager on the server.

The solution here ended up being surprisingly simple: call `Power.clear_orders()` in `on_power_orders_update()`, which is the same thing the `on_set_orders()` request manager does. This ends up only affecting the advisor, which is what we want.

---

I tested this fix on the `alex-dev` branch of `chiron-utils`. Once this PR is merged, I'll create PRs for all relevant repositories to pull in this fix.

I also included two commits for cleanup I did while working on this bug.