### PR TITLE
Don't display outdated partial order advice

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2398,6 +2398,14 @@ export class ContentGame extends React.Component {
             moveSuggestionForCurrentPower,
             STRINGS.SUGGESTED_MOVE_PARTIAL,
         );
+        // Don't display partial order advice if full order advice is newer
+        if (
+            latestMoveSuggestionFull !== null &&
+            latestMoveSuggestionPartial !== null &&
+            latestMoveSuggestionFull.time_sent > latestMoveSuggestionPartial.time_sent
+        ) {
+            latestMoveSuggestionPartial = null;
+        }
 
         let fullSuggestionComponent = null;
         let partialSuggestionComponent = null;


### PR DESCRIPTION
If the full order advice is newer, then the partial order advice no longer applies and should not be shown.

I noticed this while working on #118, but I didn't handle it then because it's much less important.