### PR TITLE
Prevent order advice from overflowing

### DIFF
--- a/diplomacy/web/src/index.css
+++ b/diplomacy/web/src/index.css
@@ -476,6 +476,8 @@ button.collapsed .roll {
 .move-suggestion-list > .cs-message-list__scroll-wrapper {
   padding-left: 0.25em;
   padding-right: 0.25em;
+  /* Not clear why, but needed for scrolling on overflow to work */
+  position: absolute;
 }
 
 /** Page login. **/


### PR DESCRIPTION
I'm not sure why this was happening, but over-filling the move advice would cause the component to grow, not to scroll. I made a fix from experimenting with CSS using the Firefox developer tools, but I have no clue why it works!

Here are screenshots of the old and new behavior:

![Screenshot of overflowing order advice component](https://github.com/user-attachments/assets/5af021a1-584d-4545-90ef-eb2fac109d36)
![Screenshot of scrolling order advice component](https://github.com/user-attachments/assets/db920ecd-d366-4ba3-bb0f-056bcedb0228)
