### PR TITLE
Use outgoing message color for message advice

### DIFF
--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -2242,7 +2242,7 @@ export class ContentGame extends React.Component {
                                                                 message: msg.message,
                                                                 sent: msg.time_sent,
                                                                 sender: msg.sender,
-                                                                direction: "incoming",
+                                                                direction: "outgoing",
                                                                 position: "single",
                                                             }}
                                                             avatarPosition={"tl"}


### PR DESCRIPTION
During the demo at the PI meeting, it was pointed out that the color for message advice should match the color of the current player sending messages.

Here is a screenshot showing the new color for message advice:

![Screenshot showing the darker color of message advice](https://github.com/user-attachments/assets/c341b609-c5be-458c-8b64-eb50b9cd84c7)
