### PR TITLE
Fix `SuggestionType.to_parsable()` for Python 3.11

### DIFF
--- a/diplomacy/utils/constants.py
+++ b/diplomacy/utils/constants.py
@@ -84,8 +84,8 @@ class SuggestionType(IntFlag):
         """Parse string representation of flags into an enum.
 
         For example:
-        >>> SuggestionType.parse("MOVE|MESSAGE")
-        <SuggestionType.MOVE|MESSAGE: 3>
+        >>> SuggestionType.parse("MESSAGE|MOVE")
+        <SuggestionType.MESSAGE|MOVE: 3>
         """
         names = string.split("|")
         value = SuggestionType.NONE
@@ -97,7 +97,16 @@ class SuggestionType(IntFlag):
         """Convert enum to a parseable string representation.
 
         For example:
-        >>> (SuggestionType.MOVE | SuggestionType.MESSAGE).to_parsable()
-        'MOVE|MESSAGE'
+        >>> (SuggestionType.MESSAGE | SuggestionType.MOVE).to_parsable()
+        'MESSAGE|MOVE'
         """
-        return str(self)[len(self.__class__.__name__) + 1 :]
+        # Short circuit because Python 3.11 and later
+        # don't include `0` values in `__iter__()` output
+        if self == self.NONE:
+            return self.NONE.name
+
+        names = [item.name for item in self.__class__ if item in self]
+        # `NONE` is trivially included in each enum, so manually remove it
+        if self.NONE.name in names:
+            names.remove(self.NONE.name)
+        return "|".join(names)

--- a/diplomacy/utils/tests/test_constants.py
+++ b/diplomacy/utils/tests/test_constants.py
@@ -1,0 +1,24 @@
+"""Tests for `constants.py`."""
+
+from diplomacy.utils.constants import SuggestionType
+
+
+def test_suggestion_types_parse() -> None:
+    """Test `SuggestionType.parse()`."""
+    assert SuggestionType.parse("NONE") == SuggestionType.NONE
+    assert SuggestionType.parse("OPPONENT_MOVE") == SuggestionType.OPPONENT_MOVE
+    assert SuggestionType.parse("MESSAGE|MOVE") == SuggestionType.MESSAGE | SuggestionType.MOVE
+
+
+def test_suggestion_types_to_parsable() -> None:
+    """Test `SuggestionType.to_parsable()`."""
+    assert SuggestionType.NONE.to_parsable() == "NONE"
+    assert SuggestionType.OPPONENT_MOVE.to_parsable() == "OPPONENT_MOVE"
+    assert (SuggestionType.MESSAGE | SuggestionType.MOVE).to_parsable() == "MESSAGE|MOVE"
+
+
+def test_suggestion_types_round_trip() -> None:
+    """Ensures round trip works for every possible value."""
+    values = [SuggestionType(i) for i in range(0, max(SuggestionType) * 2)]
+    for value in values:
+        assert value == SuggestionType.parse(value.to_parsable())


### PR DESCRIPTION
I created the function back when we were running `diplomacy` with Python 3.7 and only used the function in Cicero (which also uses Python 3.7), so I never realized that the function didn't work properly in Python 3.11. It took until I tried using the function in `chiron-utils`, which uses Python 3.11, for me to notice!

The problem is that `IntFlag.__str__()` was changed in Python 3.11, which messed up my logic and caused `to_parsable()` to output the empty string instead of the value it was supposed to. I therefore rewrote `to_parsable()` to work the same for both Python 3.7 and 3.11. The new implementation changed the order of members in the generated string, so I changed the docstrings accordingly.

To prevent missing any more bugs, I wrote some tests. They helped me find multiple bugs in my implementation. Now that all tests pass, I'm _pretty_ confident that my implementation is correct!